### PR TITLE
Update Gtm.php block

### DIFF
--- a/app/code/community/CVM/GoogleTagManager/Block/Gtm.php
+++ b/app/code/community/CVM/GoogleTagManager/Block/Gtm.php
@@ -95,7 +95,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 			// Build products array.
 			foreach ($order->getAllVisibleItems() as $item) {
-				$product = Mage::getModel('catalog/product')->loadByAttribute('sku',$item->getSku());
+				$product = Mage::getModel('catalog/product')->load($item->getProductId());
 				$product_categories = $product->getCategoryIds();
 				$categories = array();
 				foreach ($product_categories as $category) {


### PR DESCRIPTION
Loading product model by sku throws error for bundle products with a dynamic sku. Changed to load product using product ID.
