### PR TITLE
Google tagmanager code directly after body tag

### DIFF
--- a/app/design/frontend/base/default/layout/googletagmanager.xml
+++ b/app/design/frontend/base/default/layout/googletagmanager.xml
@@ -11,7 +11,7 @@
 <layout version="0.1.0">
 	<default>
 		<reference name="after_body_start">
-			<block type="googletagmanager/gtm" name="google_tag_manager" as="google_tag_manager" template="googletagmanager/gtm.phtml" />
+			<block type="googletagmanager/gtm" name="google_tag_manager" as="google_tag_manager" template="googletagmanager/gtm.phtml" before="-"/>
 		</reference>
 	</default>
 </layout>


### PR DESCRIPTION
Currently the Google tag manager code is placed somewhere after the body.
But webmaster tools demand it be placed directly after the opening body tag to function properly.
I added the before tag to make sure this happens.
