### PR TITLE
Only output transactionShippingMethod for non-virtual Orders

### DIFF
--- a/app/code/community/CVM/GoogleTagManager/Block/Gtm.php
+++ b/app/code/community/CVM/GoogleTagManager/Block/Gtm.php
@@ -89,7 +89,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 					'transactionTax' => round($order->getBaseTaxAmount(),2),
 					'transactionPaymentType' => $order->getPayment()->getMethodInstance()->getTitle(),
 					'transactionCurrency' => $order->getOrderCurrencyCode(),
-					'transactionShippingMethod' => $order->getShippingCarrier()->getCarrierCode(),
+					'transactionShippingMethod' => ($order->getIsVirtual() ? '' : $order->getShippingCarrier()->getCarrierCode()),
 					'transactionPromoCode' => $order->getCouponCode(),
 					'transactionProducts' => array()
 				);
@@ -99,7 +99,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 				$data['transactionTotal'] += $order->getBaseGrandTotal();
 				$data['transactionShipping'] += $order->getBaseShippingAmount();
 				$data['transactionTax'] += $order->getBaseTaxAmount();
-				$data['transactionShippingMethod'] .= '|'.$order->getShippingCarrier()->getCarrierCode();
+				$data['transactionShippingMethod'] .= '|'.($order->getIsVirtual() ? '' : $order->getShippingCarrier()->getCarrierCode());
 			}
 
 			// Build products array.


### PR DESCRIPTION
transactionShippingMethod was unconditionally attempting to output the
shipping "Carrier Code". This is fine in most cases, but for "virtual"
orders, no CarrierCode is defined, resulting in an illegal offset error
(internal to Magento) when the non-existent carrier information is
requested.

To avoid this, add a ->getIsVirtual() check on the $order, and only
request Shipping Carrier information for non-Virtual orders. This is the
same logic (though not exactly the same method) used within core Magento
code within the Checkout process, and so appears to be an expected
condition for accessing such data.
